### PR TITLE
Get the actual client IP if the request was forwarded by a proxy

### DIFF
--- a/web/standalone/sendmessage.php
+++ b/web/standalone/sendmessage.php
@@ -12,6 +12,8 @@ if($_SERVER['REQUEST_METHOD'] == 'POST' && $_SESSION['lastchat'] < time())
 	$data = json_decode(trim(file_get_contents('php://input')));
 	$data->timestamp = $timestamp;
 	$data->ip = $_SERVER['REMOTE_ADDR'];
+	if(isset($_SERVER['HTTP_X_FORWARDED_FOR']))
+		$data->ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
 	$old_messages = json_decode(file_get_contents('dynmap_webchat.json'), true);
 	if(!empty($old_messages))
 	{


### PR DESCRIPTION
This handy change will show the clients correct IP, and if available, match that to the in game name even when the backend server is hosted behind a proxying apache server.
