### PR TITLE
Dynmap web server shouldn't trust X-Forwarded-For all the time

### DIFF
--- a/src/main/java/org/dynmap/servlet/SendMessageServlet.java
+++ b/src/main/java/org/dynmap/servlet/SendMessageServlet.java
@@ -81,19 +81,22 @@ public class SendMessageServlet extends HttpServlet {
 
             final Message message = new Message();
 
-            if(userID.equals(LoginServlet.USERID_GUEST)) {
+            if (userID.equals(LoginServlet.USERID_GUEST)) {
                 message.name = "";
-                if(trustclientname) {
+                if (trustclientname) {
                     message.name = String.valueOf(o.get("name"));
                 }
                 boolean isip = true;
-                if((message.name == null) || message.name.equals("")) {
-                    /* If proxied client address, get original */
-                    if(request.getHeader("X-Forwarded-For") != null)
-                        message.name = request.getHeader("X-Forwarded-For");
+                if ((message.name == null) || message.name.equals("")) {
                     /* If from loopback, we're probably getting from proxy - need to trust client */
-                    else if(request.getRemoteAddr() == "127.0.0.1")
-                        message.name = String.valueOf(o.get("name"));
+                    if (request.getRemoteAddr().equals("127.0.0.1")) {
+                        /* If proxied client address, get original IP */
+                        if (request.getHeader("X-Forwarded-For") != null) {
+                            message.name = request.getHeader("X-Forwarded-For");
+                        } else {
+                            message.name = String.valueOf(o.get("name"));
+                        }
+                    }
                     else
                         message.name = request.getRemoteAddr();
                 }


### PR DESCRIPTION
When dynmap webserver is used on its own listening on external interface, it blindly trusts X-Forwarded-For header which can be added by a malicious user.

Example :
`curl 'http://myserver:8123/up/sendmessage' --data '{"name":"","message":"hello"}' -H 'X-Forwarded-For: 42.42.42.42'`

There should be an option to set trusted IP addresses (defaulting to 127.0.0.1 and ::1 perhaps) from which the X-Forwarded-For header will be considered.
