### PR TITLE
Add ability to run configurable shell scripts before/after writing tile images

### DIFF
--- a/src/main/java/org/dynmap/DynmapCore.java
+++ b/src/main/java/org/dynmap/DynmapCore.java
@@ -39,6 +39,7 @@ import org.dynmap.markers.impl.MarkerAPIImpl;
 import org.dynmap.servlet.FileLockResourceHandler;
 import org.dynmap.servlet.JettyNullLogger;
 import org.dynmap.servlet.LoginServlet;
+import org.dynmap.utils.FileLockManager;
 import org.dynmap.web.BanIPFilter;
 import org.dynmap.web.CustomHeaderFilter;
 import org.dynmap.web.FilterHandler;
@@ -344,6 +345,10 @@ public class DynmapCore {
         bettergrass = configuration.getBoolean("better-grass", false);
         /* Load full render processing player limit */
         fullrenderplayerlimit = configuration.getInteger("fullrenderplayerlimit", 0);
+                        
+        /* Load preupdate/postupdate commands */
+        FileLockManager.preUpdateCommand = configuration.getString("preupdatecommand", "");
+        FileLockManager.postUpdateCommand = configuration.getString("postupdatecommand", "");
 
         /* Load block models */
         HDBlockModels.loadModels(this, configuration);

--- a/src/main/java/org/dynmap/utils/FileLockManager.java
+++ b/src/main/java/org/dynmap/utils/FileLockManager.java
@@ -26,6 +26,8 @@ public class FileLockManager {
     private static Object lock = new Object();
     private static HashMap<String, Integer> filelocks = new HashMap<String, Integer>();
     private static final Integer WRITELOCK = new Integer(-1);
+    public static String preUpdateCommand = null;
+    public static String postUpdateCommand = null;
     /**
      * Get write lock on file - exclusive lock, no other writers or readers
      * @throws InterruptedException
@@ -223,9 +225,23 @@ public class FileLockManager {
                     try { f.close(); } catch (IOException iox) { done = false; }
                 }
                 if(done) {
+                    if (preUpdateCommand != null && !preUpdateCommand.isEmpty()) {
+                        try {
+                            new ProcessBuilder(preUpdateCommand, fnew.getAbsolutePath()).inheritIO().start().waitFor();
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
+                    }
                     fcur.renameTo(fold);
                     fnew.renameTo(fname);
                     fold.delete();
+                    if (postUpdateCommand != null && !postUpdateCommand.isEmpty()) {
+                        try {
+                            new ProcessBuilder(postUpdateCommand, fname.getAbsolutePath()).inheritIO().start().waitFor();
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Add ability to run configurable "preupdate" and "postupdate" shell scripts during image file writing.

Preupdate runs before replacing the .png, postupdate runs after. Both wait for completion before continuing, so scripts should be fast, or fork into the background themselves if appropriate. The image file name is provided as an argument.

Expected use-cases:
-Run optipng or similar in preupdate
-Upload to webserver or flush caches in postupdate

I'm sure there are others too. :)
