### PR TITLE
Fix javadoc errors for building with Java SE 8

### DIFF
--- a/src/main/java/org/dynmap/DynmapCore.java
+++ b/src/main/java/org/dynmap/DynmapCore.java
@@ -1783,7 +1783,7 @@ public class DynmapCore implements DynmapCommonAPI {
     }
     /**
      * Send generic message to all web users
-     * @param sender - label for sender of message ("[<sender>] nessage") - if null, no from notice
+     * @param sender - label for sender of message ("[&lt;sender&gt;] message") - if null, no from notice
      * @param msg - message to be sent
      */
     public boolean sendBroadcastToWeb(String sender, String msg) {

--- a/src/main/java/org/dynmap/common/DynmapCommandSender.java
+++ b/src/main/java/org/dynmap/common/DynmapCommandSender.java
@@ -9,7 +9,7 @@ public interface DynmapCommandSender {
     public boolean hasPrivilege(String privid);
     /**
      * Send given message to command sender
-     * @param msg - message to be sent (with color codes marked &0 to &F)
+     * @param msg - message to be sent (with color codes marked &amp;0 to &amp;F)
      */
     public void sendMessage(String msg);
     /**

--- a/src/main/java/org/dynmap/common/DynmapServerInterface.java
+++ b/src/main/java/org/dynmap/common/DynmapServerInterface.java
@@ -27,7 +27,7 @@ public abstract class DynmapServerInterface {
     public abstract void scheduleServerTask(Runnable run, long delay);
     /**
      * Call method on server-safe thread
-     * @param call - Callable method
+     * @param task - Callable method
      * @return future for completion of call
      */
     public abstract <T> Future<T> callSyncMethod(Callable<T> task);
@@ -49,7 +49,7 @@ public abstract class DynmapServerInterface {
     /**
      * Get offline player
      * @param name - player name
-     * @reurn player (offline or not)
+     * @return player (offline or not)
      */
     public abstract DynmapPlayer getOfflinePlayer(String name);
     
@@ -146,12 +146,12 @@ public abstract class DynmapServerInterface {
      * @param x - X coordinate
      * @param y - Y coordinate
      * @param z - Z coordinate
-     * @return block ID, or -1 if chunk at given coordainte isnt loaded
+     * @return block ID, or -1 if chunk at given coordinate isn't loaded
      */
     public abstract int getBlockIDAt(String wname, int x, int y, int z);
     /**
      * Get current TPS for server (20.0 is nominal)
-     * @returns ticks per second
+     * @return ticks per second
      */
     public abstract double getServerTPS();
     /**
@@ -184,7 +184,7 @@ public abstract class DynmapServerInterface {
      * Open resource (check all mods)
      * @param modid - mod id
      * @param rname - resource namep
-     * @returns stream, or null
+     * @return stream, or null
      */
     public InputStream openResource(String modid, String rname) {
         return null;

--- a/src/main/java/org/dynmap/exporter/OBJExport.java
+++ b/src/main/java/org/dynmap/exporter/OBJExport.java
@@ -199,7 +199,7 @@ public class OBJExport {
     /**
      * Process export
      * 
-     * @param sennder - command sender: use for feedback messages
+     * @param sender - command sender: use for feedback messages
      * @return true if successful, false if not
      */
     public boolean processExport(DynmapCommandSender sender) {

--- a/src/main/java/org/dynmap/hdmap/HDPerspectiveState.java
+++ b/src/main/java/org/dynmap/hdmap/HDPerspectiveState.java
@@ -76,7 +76,7 @@ public interface HDPerspectiveState {
     double getPatchV();
     /**
      * Light level cache
-     * @param index of light level (0-3)
+     * @param idx - index of light level (0-3)
      */
     LightLevels getCachedLightLevels(int idx);
 }

--- a/src/main/java/org/dynmap/modsupport/impl/ModTextureDefinitionImpl.java
+++ b/src/main/java/org/dynmap/modsupport/impl/ModTextureDefinitionImpl.java
@@ -76,7 +76,7 @@ public class ModTextureDefinitionImpl implements ModTextureDefinition {
     }
 
     /**
-     * Set texture path for texture resources (base path for resource loads from mod - for 1.6.x, default is assets/<modid>/textures/blocks)
+     * Set texture path for texture resources (base path for resource loads from mod - for 1.6.x, default is assets/&lt;modid&gt;/textures/blocks)
      * @param txtpath - texture resource base path
      */
     @Override
@@ -183,7 +183,7 @@ public class ModTextureDefinitionImpl implements ModTextureDefinition {
      * @param id - texture ID
      * @param filename - texture file name (including .png)
      * @param xcount - horizontal patch count in texture file
-     * @param ycound - vertical patch count in texture file
+     * @param ycount - vertical patch count in texture file
      * @return TextureFile associated with resource
      */
     @Override
@@ -197,7 +197,7 @@ public class ModTextureDefinitionImpl implements ModTextureDefinition {
      * @param id - texture ID
      * @param filename - texture file name (including .png)
      * @param xcount - horizontal patch count in texture file
-     * @param ycound - vertical patch count in texture file
+     * @param ycount - vertical patch count in texture file
      * @return CustomTextureFile associated with resource: use methods on this to define the custom patches within the file
      */
     @Override

--- a/src/main/java/org/dynmap/utils/FileLockManager.java
+++ b/src/main/java/org/dynmap/utils/FileLockManager.java
@@ -30,7 +30,6 @@ public class FileLockManager {
     public static String postUpdateCommand = null;
     /**
      * Get write lock on file - exclusive lock, no other writers or readers
-     * @throws InterruptedException
      */
     public static boolean getWriteLock(File f) {
         String fn = f.getPath();

--- a/src/main/java/org/dynmap/utils/TileFlags.java
+++ b/src/main/java/org/dynmap/utils/TileFlags.java
@@ -12,7 +12,7 @@ import org.dynmap.Log;
  * 
  * Represents a flag for each tile, with 2D coordinates based on 0,0 origin.  Flags are grouped
  * 64 x 64, represented by an array of 64 longs.  Each set is stored in a hashmap, keyed by a long
- * computed by ((x/64)<<32)+(y/64).
+ * computed by ((x/64)&lt;&lt;32)+(y/64).
  * 
  */
 public class TileFlags {


### PR DESCRIPTION
More information about doclint (which is what checks syntax for javadoc comments) can be found here:
http://openjdk.java.net/jeps/172
