### PR TITLE
Add Chrome 38+ support

### DIFF
--- a/src/main/resources/extracted/web/css/dynmap_style.css
+++ b/src/main/resources/extracted/web/css/dynmap_style.css
@@ -17,6 +17,7 @@
 
 .dynmap .map .tile img, img {
     image-rendering: -moz-crisp-edges;
+    image-rendering: pixelated;
     -ms-interpolation-mode: nearest-neighbor;
 }
 


### PR DESCRIPTION
This turns off image filtering in Chrome 38 and its future versions.
