### PR TITLE
Fixed "delete polyline" message.

### DIFF
--- a/src/main/java/org/dynmap/markers/impl/MarkerAPIImpl.java
+++ b/src/main/java/org/dynmap/markers/impl/MarkerAPIImpl.java
@@ -220,9 +220,9 @@ public class MarkerAPIImpl implements MarkerAPI, Event.Listener<DynmapWorld> {
 
             this.set = m.getMarkerSet().getMarkerSetID();
             if(deleted) 
-                msg = "polydeleted";
+                msg = "linedeleted";
             else
-                msg = "polyupdated";
+                msg = "lineupdated";
         }
         @Override
         public boolean equals(Object o) {

--- a/src/main/resources/extracted/web/js/markers.js
+++ b/src/main/resources/extracted/web/js/markers.js
@@ -433,7 +433,7 @@ componentconstructors['markers'] = function(dynmap, configuration) {
 			deleteMarker(set, set.areas[msg.id]);
 			delete set.areas[msg.id];
 		}
-		else if(msg.msg == 'polyupdated') {
+		else if(msg.msg == 'lineupdated') {
 			var set = dynmapmarkersets[msg.set];
 			deleteMarker(set, set.lines[msg.id]);
 			


### PR DESCRIPTION
Server and client were using different message names so deleted polylines didn't go away without a refresh.

I could have just changed `linedeleted` to `polydeleted` on the client but `lineupdated`/`linedeleted` seemed to be better names since they mirror the command names.
