### PR TITLE
More informative error message when a db fails

### DIFF
--- a/src/main/resources/extracted/web/standalone/MySQL_update.php
+++ b/src/main/resources/extracted/web/standalone/MySQL_update.php
@@ -51,10 +51,10 @@ if(isset($_REQUEST['serverid'])) {
 
 $content = getStandaloneFile('dynmap_' . $world . '.json');
 if (!isset($content)) {
-    header('HTTP/1.0 500 Error');
-    echo "<h1>500 Error</h1>";
+    header('HTTP/1.0 503 Database Unavailable');
+    echo "<h1>503 Database Unavailable</h1>";
     echo 'Error reading database - ' . $fname . ' #' . $serverid;
-	cleanupDb();
+    cleanupDb();
     exit;
 }
 


### PR DESCRIPTION
When the DB fails, this will show the user a "Could not update map: Database Unavailable" as opposed to "Could not update map: Error".

Basing this on a 503 (Service Unavailable) vs. the 500 (Internal Server Error) is probably more appropriate as well.

Also fix the tab before the cleanupDb() to be 4 spaces.
