### PR TITLE
Fix bug in MySQL connection pooling

### DIFF
--- a/src/main/java/org/dynmap/storage/mysql/MySQLMapStorage.java
+++ b/src/main/java/org/dynmap/storage/mysql/MySQLMapStorage.java
@@ -508,6 +508,7 @@ public class MySQLMapStorage extends MapStorage {
                     if (cpool[i] != null) { // Found one
                         c = cpool[i];
                         cpool[i] = null;
+                        break;
                     }
                 }
                 if (c == null) {


### PR DESCRIPTION
If someone asks for a connection and the pool of existing connections has more than a single item, all but the first will be lost.  This eventually leads to a hang where the pool of connections is empty, but the caching logic thinks the pool is full and won't create a new connection.

This is easy to run into if you have a bunch of render threads on a fast machine.  Any rendering operations will hang, the web interface will become unresponsive, and shutting down the server will produce a bunch of errors similar to:
```
[pool-6-thread-3/ERROR]: [dynmap] Tile read error - Interruped
```