### PR TITLE
Serve blank png from internal memory. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,10 @@
 			<id>sonatype-nexus-releases</id>
 			<url>https://oss.sonatype.org/content/repositories/releases</url>
 		</repository>
+		<repository>
+			<id>mikeprimm</id>
+			<url>http://repo.mikeprimm.com</url>
+		</repository>
 	</repositories>
 
 	<dependencies>

--- a/src/main/java/org/dynmap/servlet/MapStorageResourceHandler.java
+++ b/src/main/java/org/dynmap/servlet/MapStorageResourceHandler.java
@@ -28,7 +28,7 @@ import java.io.OutputStream;
 public class MapStorageResourceHandler extends AbstractHandler {
 
     private DynmapCore core;
-    private BufferedImage blank = new BufferedImage(128, 128, BufferedImage.TYPE_INT_ARGB);;
+    private BufferedImage blank = new BufferedImage(128, 128, BufferedImage.TYPE_INT_ARGB);
 
     @Override
     public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {


### PR DESCRIPTION
Instead of loading the blank png from disk, serve a blank png out of memory. This will fix issues with Mixed content warnings when reverse proxying and adding ssl as reported in the following issues:

- webbukkit/dynmap#1762
- webbukkit/dynmap#2025

Live demo of fixed: https://map.henry.network/
Live demo of broken: https://ardacraft.io/map/