### PR TITLE
Avoid deprecated(PHP 5.3) and removed(PHP 7) function. (`split()` => `explode()`)

### DIFF
--- a/src/main/resources/extracted/web/standalone/MySQL_login.php
+++ b/src/main/resources/extracted/web/standalone/MySQL_login.php
@@ -48,7 +48,7 @@ if(!empty($lines)) {
 	$cnt = count($lines) - 1;
 	$changed = false;
 	for($i=1; $i < $cnt; $i++) {
-		list($uid, $pc, $hsh) = split('=', rtrim($lines[$i]));
+		list($uid, $pc, $hsh) = explode('=', rtrim($lines[$i]));
 		if($uid == $useridlc) continue;
 		if(array_key_exists($uid, $pendingreg)) {
 			$newlines[] = $uid . '=' . $pc . '=' . $hsh;

--- a/src/main/resources/extracted/web/standalone/MySQL_register.php
+++ b/src/main/resources/extracted/web/standalone/MySQL_register.php
@@ -66,7 +66,7 @@ if(strcmp($useridlc, '-guest-')) {
 		if(!empty($lines)) {
 			$cnt = count($lines) - 1;
 			for($i=1; $i < $cnt; $i++) {
-				list($uid, $pc, $hsh) = split('=', rtrim($lines[$i]));
+				list($uid, $pc, $hsh) = explode('=', rtrim($lines[$i]));
 				if($uid == $useridlc) continue;
 				if(array_key_exists($uid, $pendingreg)) {
 					$newlines[] = $uid . '=' . $pc . '=' . $hsh;

--- a/src/main/resources/extracted/web/standalone/login.php
+++ b/src/main/resources/extracted/web/standalone/login.php
@@ -47,7 +47,7 @@ if(!empty($lines)) {
 	$cnt = count($lines) - 1;
 	$changed = false;
 	for($i=1; $i < $cnt; $i++) {
-		list($uid, $pc, $hsh) = split('=', rtrim($lines[$i]));
+		list($uid, $pc, $hsh) = explode('=', rtrim($lines[$i]));
 		if($uid == $useridlc) continue;
 		if(array_key_exists($uid, $pendingreg)) {
 			$newlines[] = $uid . '=' . $pc . '=' . $hsh;

--- a/src/main/resources/extracted/web/standalone/register.php
+++ b/src/main/resources/extracted/web/standalone/register.php
@@ -57,7 +57,7 @@ if(strcmp($useridlc, '-guest-')) {
 		if(!empty($lines)) {
 			$cnt = count($lines) - 1;
 			for($i=1; $i < $cnt; $i++) {
-				list($uid, $pc, $hsh) = split('=', rtrim($lines[$i]));
+				list($uid, $pc, $hsh) = explode('=', rtrim($lines[$i]));
 				if($uid == $useridlc) continue;
 				if(array_key_exists($uid, $pendingreg)) {
 					$newlines[] = $uid . '=' . $pc . '=' . $hsh;


### PR DESCRIPTION
`split()` has been deprecated for PHP 5.3.0 and removed in PHP 7.  Furthermore, `explode()` is faster for what this is trying to achieve.