### PR TITLE
Fixes for the standalone server when using MySql

### DIFF
--- a/src/main/resources/extracted/web/standalone/MySQL_configuration.php
+++ b/src/main/resources/extracted/web/standalone/MySQL_configuration.php
@@ -23,6 +23,8 @@ $content = getStandaloneFile('dynmap_config.json');
 
 header('Content-type: application/json; charset=utf-8');
 
+$json = json_decode($content);
+
 if (!$loginenabled) {
 	echo $content;
 }
@@ -30,7 +32,6 @@ else if($json->loginrequired && !$loggedin) {
     echo "{ \"error\": \"login-required\" }";
 }
 else {
-	$json = json_decode($content);
 	$uid = '[' . strtolower($userid) . ']';
 	$json->loggedin = $loggedin;
 	$wcnt = count($json->worlds);

--- a/src/main/resources/extracted/web/standalone/MySQL_funcs.php
+++ b/src/main/resources/extracted/web/standalone/MySQL_funcs.php
@@ -18,6 +18,12 @@ function abortDb($errormsg) {
 function initDbIfNeeded() {
    global $db, $dbhost, $dbuserid, $dbpassword, $dbname, $dbport;
    
+   $pos = strpos($dbname, '?');
+
+   if ($pos) {
+      $dbname = substr($dbname, 0, $pos);
+   }
+   
    if (!$db) {
       $db = mysqli_connect('p:' . $dbhost, $dbuserid, $dbpassword, $dbname, $dbport);
       if (mysqli_connect_errno()) {


### PR DESCRIPTION
Fixed a few issues when using a standalone webserver in conjunction with MySql
- fixed an issue where the required login would be ignored when running the map with a standalone server. The $json variable was accessed before even decoding the content.
- you can now set the dbname to something like dbname?useSSL=false without a mysqli connection error