### PR TITLE
Add support for 1.8 top and bottom buttons

### DIFF
--- a/src/main/resources/models_1.txt
+++ b/src/main/resources/models_1.txt
@@ -243,6 +243,9 @@ boxblock:id=96,data=8,data=9,data=10,data=11,ymin=0.8125
 # Carrot
 # Potatoes
 patchblock:id=59,id=141,id=142,data=*,patch0=VertX075,patch1=VertX075@90,patch2=VertX025,patch3=VertX025@90
+# Stone Button - facing bottom
+# Wooden Button - facing bottom
+boxblock:id=77,id=143,data=0,data=8,xmin=0.3125,xmax=0.6875,ymin=0.875,zmin=0.375,zmax=0.625
 # Stone Button - facing south
 # Wooden Button - facing south
 boxblock:id=77,id=143,data=1,data=9,xmax=0.125,ymin=0.375,ymax=0.625,zmin=0.3125,zmax=0.6875
@@ -255,6 +258,9 @@ boxblock:id=77,id=143,data=3,data=11,zmax=0.125,ymin=0.375,ymax=0.625,xmin=0.312
 # Stone Button - facing east
 # Wooden Button - facing east
 boxblock:id=77,id=143,data=4,data=12,zmin=0.875,ymin=0.375,ymax=0.625,xmin=0.3125,xmax=0.6875
+# Stone Button - facing top
+# Wooden Button - facing top
+boxblock:id=77,id=143,data=5,data=13,xmin=0.3125,xmax=0.6875,ymax=0.125,zmin=0.375,zmax=0.625
 # Rails - flat - east/west
 # Powered rails - flat - east/west
 # Detector rails - flat - east/west


### PR DESCRIPTION
![Preview of 1.8 button fixes](http://i.imgur.com/gB2ahkk.png)

Minecraft 1.8 allowed buttons to be placed on floors and ceilings; that is, on the top and bottom faces of blocks. This PR allows Dynmap to render these buttons properly, instead of as full blocks.

To try this PR on your server, you can:

* [Save the contents of this gist into `plugins/dynmap/renderdata/fixed-models.txt`](https://gist.github.com/RoyCurtis/3160f02ac5d45438881b467d3ae2472e) **OR**
* [Use this custom build of Dynmap bukkit with the fix applied](https://github.com/RoyCurtis/DynmapCore/releases/tag/2.5-patch1)

# Testing

Tested on local PaperSpigot 1.11.2 server (`git-Paper-1064 (MC: 1.11.2) (Implementing API version 1.11.2-R0.1-SNAPSHOT)`), git build of Dynmap (`core=2.5-SNAPSHOT-Dev201703190017, plugin=2.5-SNAPSHOT-Dev201703190017`)

# Notes

* Fixes https://github.com/webbukkit/dynmap/issues/2018 and https://github.com/webbukkit/dynmap/issues/1963
* [This fix was prompted by a bug report from c0wg0d on reddit](https://www.reddit.com/r/admincraft/comments/6050fu/dynmap_24_renders_buttons_incorrectly_anyone_else/)