### PR TITLE
Fix dynmap/#2179 - markers break webapp when maximum zoom levels differ between maps

### DIFF
--- a/src/main/resources/extracted/web/js/markers.js
+++ b/src/main/resources/extracted/web/js/markers.js
@@ -131,7 +131,7 @@ componentconstructors['markers'] = function(dynmap, configuration) {
 	}
 
 	function updateMarker(set, marker, mapzoom) {
-		if (set && marker) {
+		if (set && marker && marker.our_layer) {
 			// marker specific zoom supercedes set specific zoom
 			var minzoom = (marker.minzoom >= 0) ? marker.minzoom : set.minzoom;
 			var maxzoom = (marker.maxzoom >= 0) ? marker.maxzoom : set.maxzoom;


### PR DESCRIPTION
Ref: webbukkit/dynmap#2179

On changing maps, if current zoom level is higher than new map's maximum, then dynmap tries to set zoom level to the new map's maximum, which triggers a zoomed event, which tries to update markers in the middle of the map change and breaks.