### PR TITLE
Fix circle marker updates breaking realtime updates completely

### DIFF
--- a/src/main/resources/extracted/web/js/markers.js
+++ b/src/main/resources/extracted/web/js/markers.js
@@ -443,7 +443,7 @@ componentconstructors['markers'] = function(dynmap, configuration) {
 		}
 		else if(msg.msg == 'circleupdated') {
 			var set = dynmapmarkersets[msg.set];
-			deleteMarker(set, set.circle[msg.id]);
+			deleteMarker(set, set.circles[msg.id]);
 
 			var circle = { x: msg.x, y: msg.y, z: msg.z, xr: msg.xr, zr: msg.zr, label: msg.label, markup: msg.markup, desc: msg.desc,
 				color: msg.color, weight: msg.weight, opacity: msg.opacity, fillcolor: msg.fillcolor, fillopacity: msg.fillopacity, minzoom: msg.minzoom || -1, maxzoom: msg.maxzoom || -1 };
@@ -452,8 +452,8 @@ componentconstructors['markers'] = function(dynmap, configuration) {
 		}
 		else if(msg.msg == 'circledeleted') {
 			var set = dynmapmarkersets[msg.set];
-			deleteMarker(set, set.circle[msg.id]);
-			delete set.circle[msg.id];
+			deleteMarker(set, set.circles[msg.id]);
+			delete set.circles[msg.id];
 		}
 		
 		$(dynmap).trigger('markersupdated', [dynmapmarkersets]);


### PR DESCRIPTION
My plugin creates an updates circle markers, but unfortunately there is (what I think was) a typo in markers.js that made these updates throw an error that would cause all updates to cease.

I fixed the typo, circle -> circles, and updates seem to work for me now again.